### PR TITLE
Integrate MongoDB persistence for Skill Swaaap API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Este repositorio contiene un prototipo funcional (MVP) de la plataforma Skill Sw
 
 ## Requisitos previos
 
-- Node.js 18 o superior
+- Node.js 18 o superior.
+- Una cuenta gratuita en [MongoDB Atlas](https://www.mongodb.com/atlas/database) u otro proveedor que exponga un clúster de MongoDB compatible.
 
 ## Instalación y uso
 
@@ -15,7 +16,12 @@ Este repositorio contiene un prototipo funcional (MVP) de la plataforma Skill Sw
    npm install
    ```
 
-2. Arranca la API:
+2. Configura las variables de entorno necesarias (puedes usar un archivo `.env` y cargarlo con herramientas como `dotenv` o exportarlas en tu terminal):
+
+   - `MONGODB_URI`: cadena de conexión a tu base de datos MongoDB.
+   - `JWT_SECRET`: clave usada para firmar los tokens JWT (define un valor seguro en producción).
+
+3. Arranca la API:
 
    ```bash
    npm start
@@ -23,16 +29,34 @@ Este repositorio contiene un prototipo funcional (MVP) de la plataforma Skill Sw
 
    La API se expone en `http://localhost:4000`.
 
-3. Abre `index.html` en tu navegador (por ejemplo, arrastrándolo a una ventana del navegador).
+4. Abre `index.html` en tu navegador (por ejemplo, arrastrándolo a una ventana del navegador).
 
-4. Regístrate o inicia sesión para:
+5. Regístrate o inicia sesión para:
 
    - Completar tu perfil.
    - Explorar otros usuarios registrados.
    - Enviar solicitudes de intercambio de habilidades.
    - Chatear dentro de cada solicitud.
 
-> **Nota:** Este MVP utiliza almacenamiento en memoria, por lo que los datos se reinician cada vez que se reinicia el servidor.
+## Configuración de la base de datos en la nube
+
+Una forma sencilla y gratuita de hospedar la base de datos es mediante el plan **Free Forever** de MongoDB Atlas. Sigue estos pasos resumidos:
+
+1. Crea una cuenta en [MongoDB Atlas](https://www.mongodb.com/atlas/database) y selecciona la opción **Create** para iniciar un nuevo clúster (elige el nivel gratuito "M0").
+2. Define el proveedor, región y nombre del clúster según tus preferencias. Para ambientes de prueba cualquier región cercana a tus usuarios funciona bien.
+3. Cuando Atlas cree el clúster, ve a **Database Access** y crea un usuario con permisos de lectura/escritura. Guarda el usuario y contraseña, los necesitarás para la cadena de conexión.
+4. En **Network Access**, agrega tu IP (o `0.0.0.0/0` temporalmente para desarrollo) para permitir conexiones entrantes.
+5. Regresa al panel del clúster y haz clic en **Connect → Drivers**. Copia la cadena de conexión que luce como:
+
+   ```
+   mongodb+srv://<usuario>:<contraseña>@<cluster>.mongodb.net/skill-swaaap?retryWrites=true&w=majority
+   ```
+
+   Reemplaza `<usuario>` y `<contraseña>` por las credenciales que creaste y el nombre de la base de datos (`skill-swaaap` en el ejemplo) por el que prefieras.
+
+6. Establece la variable de entorno `MONGODB_URI` con esa cadena de conexión antes de iniciar el servidor (`export MONGODB_URI="..."` en Linux/macOS o usando el panel de variables en tu proveedor de hosting).
+
+Con esta configuración, los datos de usuarios, solicitudes y mensajes persistirán en tu clúster gestionado en la nube.
 
 ## Scripts disponibles
 
@@ -44,12 +68,11 @@ En la carpeta `backend`:
 
 ## Arquitectura
 
-- **Backend:** Node.js + Express con autenticación JWT, gestión de perfiles, solicitudes de intercambio y mensajería básica.
+- **Backend:** Node.js + Express con autenticación JWT, persistencia en MongoDB, gestión de perfiles, solicitudes de intercambio y mensajería básica.
 - **Frontend:** HTML, CSS y JavaScript vanilla con `fetch` para consumir la API y manejar el estado mínimo en el navegador.
 
 ## Próximos pasos sugeridos
 
-- Persistencia con una base de datos (PostgreSQL, MongoDB, etc.).
 - Validaciones adicionales y recuperación de contraseña.
 - Chat en tiempo real con WebSockets.
 - Despliegue en servicios gestionados (Railway, Render, Vercel, etc.).

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "uuid": "^9.0.1"
+    "mongodb": "^5.9.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"


### PR DESCRIPTION
## Summary
- replace the in-memory stores with MongoDB collections to persist users, requests, and request messages
- update the Express routes to read and write from MongoDB and keep API responses backward compatible
- document MongoDB Atlas setup and the environment variables required to connect to the cloud database

## Testing
- npm install *(fails: npm registry returned 403 for bcryptjs)*

------
https://chatgpt.com/codex/tasks/task_b_68e584553f2483288dafe2f3969f7289