### PR TITLE
Separate login and registration flows on landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,16 @@
     />
     <style>
       :root {
-        --bg: #0f172a;
-        --bg-soft: #1e293b;
-        --accent: #38bdf8;
-        --accent-strong: #0ea5e9;
-        --success: #22c55e;
-        --text: #f8fafc;
-        --text-muted: #cbd5f5;
-        --border: rgba(148, 163, 184, 0.25);
+        --bg: #f5f7fb;
+        --bg-soft: #ffffff;
+        --accent: #1dbf73;
+        --accent-strong: #0fa85d;
+        --success: #0fa85d;
+        --text: #0f172a;
+        --text-muted: #55627a;
+        --border: rgba(15, 23, 42, 0.08);
+        --shadow-soft: 0 16px 40px rgba(15, 23, 42, 0.08);
+        --shadow-card: 0 22px 45px rgba(15, 23, 42, 0.12);
       }
 
       * {
@@ -29,8 +31,7 @@
       body {
         margin: 0;
         font-family: 'Manrope', system-ui, sans-serif;
-        background: radial-gradient(circle at 10% 15%, rgba(34, 197, 94, 0.16), transparent 40%),
-          radial-gradient(circle at 85% 20%, rgba(56, 189, 248, 0.18), transparent 45%),
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.75), rgba(245, 247, 251, 1)),
           var(--bg);
         color: var(--text);
         min-height: 100vh;
@@ -39,16 +40,18 @@
       }
 
       header {
-        border-bottom: 1px solid var(--border);
-        padding: 1.25rem 1.5rem;
-        backdrop-filter: blur(10px);
-        background: rgba(15, 23, 42, 0.85);
+        border-bottom: 1px solid rgba(15, 23, 42, 0.05);
+        padding: 1.5rem 1.75rem;
+        background: rgba(255, 255, 255, 0.9);
+        backdrop-filter: blur(16px);
+        box-shadow: var(--shadow-soft);
       }
 
       header h1 {
         margin: 0;
-        font-size: 1.6rem;
-        letter-spacing: 0.03em;
+        font-size: 1.75rem;
+        letter-spacing: 0.01em;
+        color: #0f172a;
       }
 
       main {
@@ -60,12 +63,105 @@
       }
 
       .card {
-        background: rgba(15, 23, 42, 0.82);
+        background: var(--bg-soft);
         border: 1px solid var(--border);
-        border-radius: 18px;
-        padding: 1.5rem;
-        box-shadow: 0 25px 60px rgba(15, 23, 42, 0.35);
-        backdrop-filter: blur(20px);
+        border-radius: 24px;
+        padding: 1.75rem;
+        box-shadow: var(--shadow-card);
+      }
+
+      #auth {
+        display: grid;
+      }
+
+      .auth-layout {
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .auth-hero {
+        position: relative;
+        overflow: hidden;
+        background: linear-gradient(135deg, rgba(29, 191, 115, 0.12), rgba(56, 189, 248, 0.15));
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        color: #0f172a;
+        display: grid;
+        gap: 1rem;
+        padding: 2.25rem;
+      }
+
+      .auth-kicker {
+        font-size: 0.82rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-strong);
+        margin: 0;
+      }
+
+      .auth-hero h2 {
+        font-size: 2rem;
+        margin: 0;
+      }
+
+      .auth-hero p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.98rem;
+      }
+
+      .auth-highlights {
+        margin: 0;
+        padding-left: 1.2rem;
+        display: grid;
+        gap: 0.6rem;
+        color: #1d2a41;
+        font-size: 0.92rem;
+      }
+
+      .auth-highlights li::marker {
+        color: var(--accent-strong);
+      }
+
+      .auth-panels {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .auth-card {
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      .auth-card-header h2 {
+        margin: 0 0 0.35rem;
+      }
+
+      .auth-card-header p {
+        margin: 0;
+        color: var(--text-muted);
+        font-size: 0.9rem;
+      }
+
+      .auth-switch {
+        text-align: center;
+        font-size: 0.9rem;
+        color: var(--text-muted);
+      }
+
+      .auth-switch .link-button {
+        font-size: inherit;
+      }
+
+      @media (min-width: 960px) {
+        .auth-layout {
+          grid-template-columns: 1.15fr 0.85fr;
+          align-items: stretch;
+        }
+
+        .auth-panels {
+          align-content: start;
+        }
       }
 
       .split {
@@ -84,32 +180,35 @@
       }
 
       h2 {
-        font-size: 1.25rem;
+        font-size: 1.35rem;
         margin-bottom: 1rem;
+        color: #0b1b33;
       }
 
       form {
         display: grid;
-        gap: 0.9rem;
+        gap: 1rem;
       }
 
       label {
         font-weight: 600;
         display: block;
-        font-size: 0.9rem;
+        font-size: 0.92rem;
+        color: #1d2a41;
       }
 
       input,
       textarea,
       select {
         width: 100%;
-        padding: 0.75rem 0.9rem;
-        border-radius: 12px;
+        padding: 0.85rem 1rem;
+        border-radius: 14px;
         border: 1px solid var(--border);
-        background: rgba(15, 23, 42, 0.9);
+        background: rgba(255, 255, 255, 0.85);
         color: var(--text);
         font-family: inherit;
         font-size: 0.95rem;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
       }
 
       textarea {
@@ -117,29 +216,40 @@
         min-height: 120px;
       }
 
+      input:focus,
+      textarea:focus,
+      select:focus {
+        outline: none;
+        border-color: rgba(29, 191, 115, 0.4);
+        box-shadow: 0 0 0 4px rgba(29, 191, 115, 0.12);
+        background: #fff;
+      }
+
       button {
         background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-        color: #04111f;
+        color: #ffffff;
         border: none;
         font-weight: 700;
-        padding: 0.75rem 1.1rem;
-        border-radius: 12px;
+        padding: 0.85rem 1.35rem;
+        border-radius: 999px;
         cursor: pointer;
         transition: transform 0.2s ease, box-shadow 0.2s ease;
+        letter-spacing: 0.01em;
       }
 
       button:hover {
-        transform: translateY(-1px);
-        box-shadow: 0 12px 30px rgba(14, 165, 233, 0.25);
+        transform: translateY(-2px);
+        box-shadow: 0 18px 30px rgba(15, 23, 42, 0.12);
       }
 
       .link-button {
         background: none;
-        color: var(--accent);
+        color: var(--accent-strong);
         border: none;
         padding: 0;
         cursor: pointer;
         font-size: 0.95rem;
+        font-weight: 600;
       }
 
       .hidden {
@@ -148,8 +258,8 @@
 
       .info-text {
         color: var(--text-muted);
-        font-size: 0.9rem;
-        margin-top: -0.3rem;
+        font-size: 0.88rem;
+        margin-top: 0.35rem;
       }
 
       .list {
@@ -158,23 +268,24 @@
       }
 
       .list-item {
-        border: 1px solid var(--border);
-        border-radius: 14px;
-        padding: 0.9rem 1rem;
-        background: rgba(30, 41, 59, 0.65);
+        border: 1px solid rgba(15, 23, 42, 0.05);
+        border-radius: 18px;
+        padding: 1.1rem 1.2rem;
+        background: rgba(255, 255, 255, 0.85);
         display: grid;
-        gap: 0.35rem;
+        gap: 0.45rem;
+        box-shadow: 0 12px 28px rgba(15, 23, 42, 0.08);
       }
 
       .badge {
         display: inline-flex;
         align-items: center;
         gap: 0.35rem;
-        font-size: 0.75rem;
+        font-size: 0.76rem;
         font-weight: 700;
-        padding: 0.2rem 0.6rem;
+        padding: 0.25rem 0.7rem;
         border-radius: 999px;
-        background: rgba(56, 189, 248, 0.15);
+        background: rgba(29, 191, 115, 0.12);
         color: var(--accent);
       }
 
@@ -182,7 +293,7 @@
         display: inline-flex;
         align-items: center;
         gap: 0.4rem;
-        font-size: 0.75rem;
+        font-size: 0.78rem;
         font-weight: 700;
         text-transform: uppercase;
         letter-spacing: 0.04em;
@@ -206,40 +317,44 @@
 
       .chat {
         display: grid;
-        gap: 1rem;
+        gap: 1.1rem;
         height: 100%;
       }
 
       .chat-history {
-        border: 1px solid var(--border);
-        border-radius: 14px;
-        padding: 1rem;
-        background: rgba(30, 41, 59, 0.55);
+        border: 1px solid rgba(15, 23, 42, 0.08);
+        border-radius: 18px;
+        padding: 1.1rem;
+        background: rgba(255, 255, 255, 0.9);
         height: 260px;
         overflow-y: auto;
         display: grid;
-        gap: 0.8rem;
+        gap: 0.9rem;
+        box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.04);
       }
 
       .message {
         display: grid;
-        gap: 0.3rem;
+        gap: 0.35rem;
       }
 
       .message-author {
         font-weight: 600;
-        font-size: 0.9rem;
+        font-size: 0.95rem;
+        color: #0b1b33;
       }
 
       .timestamp {
-        font-size: 0.75rem;
+        font-size: 0.78rem;
         color: var(--text-muted);
       }
 
       .empty-state {
         color: var(--text-muted);
         text-align: center;
-        padding: 2rem 1rem;
+        padding: 2.25rem 1.2rem;
+        background: rgba(84, 104, 130, 0.06);
+        border-radius: 18px;
       }
 
       .sr-only {
@@ -255,23 +370,24 @@
       }
 
       footer {
-        border-top: 1px solid var(--border);
-        padding: 1.5rem;
+        border-top: 1px solid rgba(15, 23, 42, 0.05);
+        padding: 2rem 1.5rem;
         text-align: center;
         color: var(--text-muted);
         font-size: 0.85rem;
+        background: rgba(255, 255, 255, 0.9);
       }
 
       .danger {
-        background: #f87171;
-        color: #0f172a;
+        background: linear-gradient(135deg, #f97316, #ef4444);
+        color: #ffffff;
       }
 
       .actions {
         display: flex;
-        gap: 0.6rem;
+        gap: 0.8rem;
         flex-wrap: wrap;
-        margin-top: 0.6rem;
+        margin-top: 0.8rem;
       }
     </style>
   </head>
@@ -280,39 +396,68 @@
       <h1>Skill Swaaap · MVP</h1>
     </header>
     <main>
-      <section id="auth" class="card">
-        <div class="split split-2">
-          <div>
-            <h2>Inicia sesión</h2>
-            <form id="login-form">
-              <div>
-                <label for="login-email">Correo electrónico</label>
-                <input id="login-email" name="email" type="email" required />
+      <section id="auth">
+        <div class="auth-layout">
+          <article class="card auth-hero">
+            <p class="auth-kicker">Bienvenido a Skill Swaaap</p>
+            <h2>Intercambia talento con profesionales como tú</h2>
+            <p>
+              Conecta con especialistas de todo el mundo para aprender nuevas habilidades, ofrecer tu
+              experiencia y cerrar acuerdos de colaboración reales.
+            </p>
+            <ul class="auth-highlights">
+              <li>Perfiles verificados y solicitudes transparentes</li>
+              <li>Chats directos para coordinar cada intercambio</li>
+              <li>Panel personal para gestionar tu disponibilidad</li>
+            </ul>
+          </article>
+          <div class="auth-panels">
+            <article class="card auth-card" id="login-panel">
+              <div class="auth-card-header">
+                <h2>Inicia sesión</h2>
+                <p>Retoma tus conversaciones y gestiona tus solicitudes.</p>
               </div>
-              <div>
-                <label for="login-password">Contraseña</label>
-                <input id="login-password" name="password" type="password" required />
+              <form id="login-form">
+                <div>
+                  <label for="login-email">Correo electrónico</label>
+                  <input id="login-email" name="email" type="email" required />
+                </div>
+                <div>
+                  <label for="login-password">Contraseña</label>
+                  <input id="login-password" name="password" type="password" required />
+                </div>
+                <button type="submit">Entrar</button>
+              </form>
+              <p class="auth-switch">
+                ¿No tienes cuenta?
+                <button type="button" class="link-button" data-auth-target="register">Crea una cuenta</button>
+              </p>
+            </article>
+            <article class="card auth-card hidden" id="register-panel">
+              <div class="auth-card-header">
+                <h2>Crea tu cuenta</h2>
+                <p>Únete a la comunidad y empieza a compartir tu talento.</p>
               </div>
-              <button type="submit">Entrar</button>
-            </form>
-          </div>
-          <div>
-            <h2>Regístrate</h2>
-            <form id="register-form">
-              <div>
-                <label for="register-name">Nombre completo</label>
-                <input id="register-name" name="name" type="text" required />
-              </div>
-              <div>
-                <label for="register-email">Correo electrónico</label>
-                <input id="register-email" name="email" type="email" required />
-              </div>
-              <div>
-                <label for="register-password">Contraseña</label>
-                <input id="register-password" name="password" type="password" required />
-              </div>
-              <button type="submit">Crear cuenta</button>
-            </form>
+              <form id="register-form">
+                <div>
+                  <label for="register-name">Nombre completo</label>
+                  <input id="register-name" name="name" type="text" required />
+                </div>
+                <div>
+                  <label for="register-email">Correo electrónico</label>
+                  <input id="register-email" name="email" type="email" required />
+                </div>
+                <div>
+                  <label for="register-password">Contraseña</label>
+                  <input id="register-password" name="password" type="password" required />
+                </div>
+                <button type="submit">Crear cuenta</button>
+              </form>
+              <p class="auth-switch">
+                ¿Ya tienes cuenta?
+                <button type="button" class="link-button" data-auth-target="login">Inicia sesión</button>
+              </p>
+            </article>
           </div>
         </div>
       </section>
@@ -400,6 +545,23 @@
       const chatHistory = document.getElementById('chat-history');
       const chatForm = document.getElementById('chat-form');
       const chatMessage = document.getElementById('chat-message');
+      const authPanels = {
+        login: document.getElementById('login-panel'),
+        register: document.getElementById('register-panel')
+      };
+
+      function showAuthPanel(target) {
+        const mode = target === 'register' ? 'register' : 'login';
+        Object.entries(authPanels).forEach(([key, panel]) => {
+          panel.classList.toggle('hidden', key !== mode);
+        });
+      }
+
+      document.querySelectorAll('[data-auth-target]').forEach((toggle) => {
+        toggle.addEventListener('click', () => showAuthPanel(toggle.dataset.authTarget));
+      });
+
+      showAuthPanel('login');
 
       document.getElementById('year').textContent = new Date().getFullYear();
 
@@ -438,6 +600,7 @@
         } else {
           authSection.classList.remove('hidden');
           appSection.classList.add('hidden');
+          showAuthPanel('login');
         }
       }
 


### PR DESCRIPTION
## Summary
- redesign the authentication area with a hero card and dedicated panels for login and registration
- add client-side toggles to switch between login and registration views while keeping the rest of the app flow intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e58f92404883289130e85c5cdf98d4